### PR TITLE
Fix issue where code continued after JWT authentication errors 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,3 +47,19 @@ venv/bin/tap-salesforce --config config.json --catalog catalog.json > data/data.
 ----
 
 Or something along those lines
+
+
+## Development
+
+To make changes to this package you can install it in development mode:
+
+----
+# Set up a virtual env and activate it (if not already done)
+python -m venv venv
+source venv/bin/activate
+
+# Install the package to the venv in dev mode
+pip install -e .
+----
+
+This way you can make changes to the code locally and test as above, without rebuilding the package.

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -386,6 +386,9 @@ class Salesforce():
                 verify=False
             )
 
+            # Raise error if status code is 4XX or 5XX
+            resp.raise_for_status()
+
             # Get token out of responseS
             resp = resp.json()
 
@@ -393,7 +396,7 @@ class Salesforce():
             self.instance_url = resp.get("instance_url")
 
         except Exception as e:
-            error_message = str(e)
+            error_message = str(e).replace(encoded_jwt, "<redacted>")
             if resp is None and hasattr(e, 'response') and e.response is not None: #pylint:disable=no-member
                 resp = e.response #pylint:disable=no-member
             # NB: requests.models.Response is always falsy here. It is false if status code >= 400


### PR DESCRIPTION
# Description of change

The `requests` library doesn't throw an error if a request returns an error response; this meant that if the JWT auth failed, the code continued and set the instance URL and auth token to `None`, leading to confusing errors further on in the code.

This PR raises an error if the response is a 4xx or 5xx message, printing the response from the JWT auth call (but removing the JWT token before printing).

Also updated the readme to show how to install the package in dev mode.

# QA steps
 - [ ] automated tests passing
 - [X] manual qa steps passing (list below)

Tested by changing values in `config.json` to force the authentication to fail. Also tested a successful catalog request still works.
 
# Risks

# Rollback steps
 - revert this branch
