### PR TITLE
Fix character encoding in output

### DIFF
--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -513,23 +513,26 @@ class BulkV2(BaseBulk):
             args = {"locator": locator} if locator else {}
             headers['Content-Type'] = 'text/csv'
 
-            with tempfile.NamedTemporaryFile(mode="w+", encoding="utf8") as csv_file:
+            # Write file in binary mode to avoid breaking character encoding
+            with tempfile.NamedTemporaryFile(mode="wb+") as csv_file:
                 resp = self.sf._make_request('GET', url, headers=headers, stream=True, params=args)
-                for chunk in resp.iter_content(chunk_size=ITER_CHUNK_SIZE, decode_unicode=True):
+                for chunk in resp.iter_content(chunk_size=ITER_CHUNK_SIZE):
                     if chunk:
                         # Replace any NULL bytes in the chunk so it can be safely given to the CSV reader
-                        csv_file.write(chunk.replace('\0', ''))
+                        csv_file.write(chunk)
+                csv_file.close()
 
-                csv_file.seek(0)
-                csv_reader = csv.reader(csv_file,
-                                        delimiter=',',
-                                        quotechar='"')
+                # Re-open file in text mode
+                with open(csv_file.name) as read_csv_file:
+                    csv_reader = csv.reader(read_csv_file,
+                                            delimiter=',',
+                                            quotechar='"')
 
-                column_name_list = next(csv_reader)
+                    column_name_list = next(csv_reader)
 
-                for line in csv_reader:
-                    rec = dict(zip(column_name_list, line))
-                    yield rec
+                    for line in csv_reader:
+                        rec = dict(zip(column_name_list, line))
+                        yield rec
 
             locator = resp.headers.get('Sforce-Locator')
             if locator == 'null':

--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -519,7 +519,6 @@ class BulkV2(BaseBulk):
                 resp = self.sf._make_request('GET', url, headers=headers, stream=True, params=args)
                 for chunk in resp.iter_content(chunk_size=ITER_CHUNK_SIZE):
                     if chunk:
-                        # Replace any NULL bytes in the chunk so it can be safely given to the CSV reader
                         csv_file.write(chunk)
 
             # Re-open file in text mode

--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -514,7 +514,6 @@ class BulkV2(BaseBulk):
             args = {"locator": locator} if locator else {}
             headers['Content-Type'] = 'text/csv'
 
-            # with tempfile.NamedTemporaryFile(mode="wb+", dir="temp_csvs", delete=False) as csv_file:
             # Write file in binary mode to avoid breaking character encoding
             with tempfile.NamedTemporaryFile(mode="wb+", delete=False) as csv_file:
                 resp = self.sf._make_request('GET', url, headers=headers, stream=True, params=args)


### PR DESCRIPTION
# Description of change

When writing to temp CSV file the existing code (opening in text mode and using `decode_unicode=True` resulted in incorrectly-encoded temp CSV files, e.g:

```
...,"false","","MontrÃ©al...",...
```

Instead if we write the content in binary mode, the temp CSVs are correctly written, e.g.:

```
...,"false","","Montréal...",...
```

We then need to reopen the file in text mode to use `csv.reader` but this happens once per bulk API batch so hopefully will not be a significant overhead.

Writing in binary mode means there's no need to remove null bytes when writing - we write the file exactly as it's returned from Salesforce which should be in a readable CSV format.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
