### PR TITLE
Use correct audience value based on is_sandbox in JWT auth

### DIFF
--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -335,11 +335,10 @@ class Salesforce():
     def login(self):
         if self.is_sandbox:
             login_url = 'https://test.salesforce.com/services/oauth2/token'
+            sf_audience = 'https://test.salesforce.com'
         else:
             login_url = 'https://login.salesforce.com/services/oauth2/token'
-
-        #login_body = {'grant_type': 'refresh_token', 'client_id': self.sf_client_id,
-                     #'client_secret': self.sf_client_secret, 'refresh_token': self.refresh_token}
+            sf_audience = 'https://login.salesforce.com'
 
         private_key = None
         with open(self.sf_private_key, "r") as f:
@@ -354,11 +353,10 @@ class Salesforce():
         }
 
         # Set Salesforce JWT Payload
-        sf_aud = "https://test.salesforce.com"
         jwt_payload = {
             "iss": f"{self.sf_consumer_key}",
             "sub": f"{self.sf_user}",
-            "aud": f"{sf_aud}",
+            "aud": f"{sf_audience}",
             "exp":  f"{expiry}"
         }
 


### PR DESCRIPTION
# Description of change

JWT auth was using a hard-coded value "https://test.salesforce.com" as the audience value, which should only be used for sandboxes. Updated to change with the config value `is_salesforce`. (See [Salesforce JWT docs](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_jwt_flow.htm&type=5) for confirmation of valid values.)

Part of wellcometrust/wt-data-ops#97

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
